### PR TITLE
interception_spec: add a failing test (SystemStackError stuff)

### DIFF
--- a/spec/interception_spec.rb
+++ b/spec/interception_spec.rb
@@ -135,6 +135,19 @@ describe Interception do
     ZeroDivisionError.should === e1
   end
 
+  it "should be able to handle SystemStackErrors" do
+    shoulder = :bucket
+
+    begin
+      line = __LINE__; def twist; twist; end; twist
+    rescue Exception => e1
+      #
+    end
+
+    @exceptions.map{ |e, b| [e] + b.eval('[__LINE__, shoulder, self]') }.should == [[e1, line, :bucket, self]]
+    SystemStackError.should === e1
+  end
+
   it "should have the right exception and binding at the top level" do
     $initial_eb.last.eval("self").should == TOPLEVEL_BINDING.eval("self")
   end


### PR DESCRIPTION
Original issue: https://github.com/pry/pry/issues/942

The problem occurs in pry-rescue plugin, which the original poster uses. I really wished to fix that myself, but I stumbled upon the wall. So I just added a failing test.

The failing test errors with the following message (on 1.9.3 and higher): `can't modify frozen object (RuntimeError)`. Notice that this time it's frozen `object`, not `Class`.

On 1.8.7 the error message is different (BTW, I think we, Ruby developers, should forget about 1.8.7 now): `NameError: undefined local variable or method `shoulder'`. I'm not sure, but it looks like it cannot retrieve the correct binding.

I discovered that the problem lies somewhere around that line: https://github.com/ConradIrwin/interception/blob/e6259a786b1f9715127e9a26491331c5c525e549/ext/interception.c#L47

For what it's worth, I also found that `SystemStackError` inherits from `Exception`. It also freezes the message error string, but I don't think that's relevant. https://github.com/ruby/ruby/blob/bbe36f64a065dd6124b119590c5d4e5370c893e5/proc.c#L2154-L2157
