### PR TITLE
interception.rb: Add support for Ruby 2.1 patch releases

### DIFF
--- a/lib/interception.rb
+++ b/lib/interception.rb
@@ -134,7 +134,7 @@ module Interception
   end
 
   def self.ruby_21?
-    RUBY_VERSION == '2.1.0' && RUBY_ENGINE == 'ruby'
+    RUBY_VERSION.to_f == 2.1 && RUBY_ENGINE == 'ruby'
   end
 
   require File.expand_path('../cross_platform.rb', __FILE__)


### PR DESCRIPTION
Ruby 2.1.1 breaks compatibility with interception because the RUBY_VERSION comparison is specific to the patch release.

```
$: pry
before_session hook failed: NotImplementedError: NotImplementedError
/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/interception-0.4/lib/interception.rb:122:in `start'
(see _pry_.hooks.errors to debug)
[1] pry(main)> _pry_.hooks.errors.first.backtrace
=> ["/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/interception-0.4/lib/interception.rb:122:in `start'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/interception-0.4/lib/interception.rb:65:in `block in listen'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/interception-0.4/lib/interception.rb:64:in `synchronize'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/interception-0.4/lib/interception.rb:64:in `listen'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-rescue-1.4.0/lib/pry-rescue/core_ext.rb:74:in `enable_rescuing!'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-rescue-1.4.0/lib/pry-rescue.rb:29:in `block in <top (required)>'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/lib/pry/hooks.rb:154:in `call'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/lib/pry/hooks.rb:154:in `block (2 levels) in exec_hook'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/lib/pry/hooks.rb:152:in `map'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/lib/pry/hooks.rb:152:in `block in exec_hook'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/lib/pry/helpers/base_helpers.rb:12:in `silence_warnings'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/lib/pry/hooks.rb:151:in `exec_hook'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/lib/pry/pry_instance.rb:498:in `exec_hook'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/lib/pry/pry_instance.rb:199:in `repl_prologue'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/lib/pry/pry_instance.rb:227:in `repl'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/lib/pry/pry_class.rb:169:in `start'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/lib/pry/cli.rb:201:in `block in <top (required)>'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/lib/pry/cli.rb:70:in `call'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/lib/pry/cli.rb:70:in `block in parse_options'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/lib/pry/cli.rb:70:in `each'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/lib/pry/cli.rb:70:in `parse_options'",
 "/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/pry-0.9.12.6/bin/pry:16:in `<top (required)>'",
 "/usr/local/var/rbenv/versions/2.1.1/bin/pry:23:in `load'",
 "/usr/local/var/rbenv/versions/2.1.1/bin/pry:23:in `<main>'"]
```
