### PR TITLE
lib/interception.rb: a bit fix for ruby v2.1.X versions support.

### DIFF
--- a/lib/interception.rb
+++ b/lib/interception.rb
@@ -134,7 +134,7 @@ module Interception
   end
 
   def self.ruby_21?
-    RUBY_VERSION == '2.1.0' && RUBY_ENGINE == 'ruby'
+    RUBY_VERSION =~ /^2\.1\./ && RUBY_ENGINE == 'ruby'
   end
 
   require File.expand_path('../cross_platform.rb', __FILE__)


### PR DESCRIPTION
I send a fix patch to supports for ruby(MRI) Version 2.1.1 and later.
please merge it.

---

rspec spec -r ./spec/spec_helpers.rb
..........

Finished in 0.02943 seconds
10 examples, 0 failures
