### PR TITLE
Added test for classes that override raise (provides integration with Mulligan)

### DIFF
--- a/interception.gemspec
+++ b/interception.gemspec
@@ -13,4 +13,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
+  s.add_runtime_dependency 'binding_of_caller', "~> 0.7"
 end

--- a/lib/interception.rb
+++ b/lib/interception.rb
@@ -1,4 +1,5 @@
 require 'thread'
+require 'binding_of_caller'
 
 
 # Provides global facility for monitoring exceptions raised in your application.


### PR DESCRIPTION
Hi Conrad,

I tried to update interception to handle the case where `Kernel#raise` might be called from another class' `#raise` method (for future compatibility with Mullligan). I wasn't able to figure it out because I don't think I fully understand the creation of bindings or if they are collected in a stack or not.

But, I figured I'd at least check in a test that would need to pass to verify that it works. It fails of course, but do you think this is enough for you to whip up a quick fix?

Best,

_ michael
