### PR TITLE
backporting patch to use TracePointAPI on  MRIv2.0 series.

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -7,12 +7,11 @@ if RbConfig::CONFIG['ruby_install_name'] == 'jruby'
     f.write "install:\n\tjrubyc --javac org/pryrepl/InterceptionEventHook.java\n"
   end
 
-elsif RbConfig::CONFIG['ruby_install_name'] =~ /^ruby/ && RUBY_VERSION.to_f < 2.1
+elsif RbConfig::CONFIG['ruby_install_name'] =~ /^ruby/ && RUBY_VERSION.to_f < 2.0
 
   require 'mkmf'
   $CFLAGS += " -DRUBY_18" if RUBY_VERSION =~ /^(1.8)/
   $CFLAGS += " -DRUBY_19" if RUBY_VERSION =~ /^(1.9)/
-  $CFLAGS += " -DRUBY_20" if RUBY_VERSION =~ /^(2.0)/
   extension_name = "interception"
   dir_config(extension_name)
   create_makefile(extension_name)

--- a/ext/interception.c
+++ b/ext/interception.c
@@ -46,7 +46,7 @@ interception_stop(VALUE self)
     return Qnil;
 }
 
-#elif RUBY_19 || RUBY_20
+#elif RUBY_19
 
 void
 interception_hook(rb_event_flag_t evflag, VALUE data, VALUE self, ID mid, VALUE klass)
@@ -75,8 +75,6 @@ Init_interception()
 {
     rb_mInterception = rb_define_module("Interception");
 
-#if defined(RUBY_18) || defined(RUBY_19) || defined(RUBY_20)
     rb_define_singleton_method(rb_mInterception, "start", interception_start, 0);
     rb_define_singleton_method(rb_mInterception, "stop", interception_stop, 0);
-#endif
 }

--- a/lib/cross_platform.rb
+++ b/lib/cross_platform.rb
@@ -60,8 +60,8 @@ class << Interception
     end
 
   # For MRI
-  # @note For Ruby 2.1 and later we use the new TracePoint API.
-  elsif RUBY_VERSION.to_f >= 2.1 && RUBY_ENGINE == 'ruby'
+  # @note For Ruby 2.0 and later we use the new TracePoint API.
+  elsif RUBY_VERSION.to_f >= 2.0 && RUBY_ENGINE == 'ruby'
 
     def start
       @tracepoint ||= TracePoint.new(:raise) do |tp|


### PR DESCRIPTION
HI,  @ConradIrwin , @kyrylo .

I wrote backporting patch to use TracePointAPI on MRIv2.0 series.
unfortunately, It seems that TravisCI hasn't supports test with `2.0.0-p451` yet.
RSpec tests on my local environment is passed (below). and [`2.0.0-p353` tests on Travis](https://travis-ci.org/ygotoh/interception/jobs/19814292) is passed, too.

best,

---

```
$ ruby --version
ruby 2.0.0p451 (2014-02-24 revision 45167) [i686-linux]
$ rspec spec -r ./spec/spec_helpers.rb
..........

Finished in 0.07852 seconds
10 examples, 0 failures
'''
```
