### PR TITLE
CHANGELOG.md: The statement about the support situation of MRIv2.0 was changed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Interception changelog
 ### v0.5 (March 6, 2014)
 
 * Added support for MRI 2.1.1
-* Added support for MRI 2.0.0-p451 (Interception v0.4 supports all the
-patchlevels prior to this one)
-* Dropped support for MRI 2.0.0 with patchlevel lower than p451.
+* Added support for MRI 2.0.0-p451
+* Changed support for MRI 2.0.0 with patchlevel lower than p451
+  not using NativeExtension but using TracePointAPI which Ruby offers.
 
 ### v0.4 (January 21, 2014)
 


### PR DESCRIPTION
HI,

I rewrite tha statment aboud the supporot situation of MRIv2.0

  For MRIv2.0 with patchlevel lower than 451, the function is
  succeedingly offered not using NativeExtension but using TracePointAPI which
  Ruby offers.

regards,
